### PR TITLE
recognize streaming rpc pattern

### DIFF
--- a/grammars/protobuf.cson
+++ b/grammars/protobuf.cson
@@ -38,7 +38,7 @@
         'name': 'keyword.rpc.returns.protobuf'
       '5':
         'name': 'rpc.response.protobuf'
-    'match': '\\b(rpc)\\s+(\\w+)\\s+\\(\\s*([.|\\w]+)\\s*\\)\\s+(returns)\\s+\\(\\s*([.|\\w]+)\\s*\\)'
+    'match': '\\b(rpc)\\s+(\\w+)\\s+\\(\\s*([.|(?:stream\\s+\\w)]+)\\s*\\)\\s+(returns)\\s+\\(\\s*([.|(?:stream\\s+\\w)]+)\\s*\\)'
     'name': 'rpc.protobuf'
   }
   {

--- a/test.proto
+++ b/test.proto
@@ -48,6 +48,7 @@ message Pserson
 
 service SearchService {
   rpc Search (SearchRequest) returns (SearchResponse);
+  rpc StreamingSearch (stream SearchRequest) returns (stream SearchReponse);
 }
 
 option java_package = "com.example.foo";


### PR DESCRIPTION
The `rpc.request.protobuf` and `rpc.response.protobuf`
captures can now be prefixed with “stream “.

This adds support for streaming rpc calls as defined by the gRPC
project (which is developed in conjunction with protocol buffers). The
behavior is modeled in gRPC’s docs:
http://www.grpc.io/docs/guides/concepts.html

A test case is also added to `test.proto`.
